### PR TITLE
Update xsigner-sdk-test 0.0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "react-toastify": "^9.1.3",
     "sass": "^1.63.6",
     "useink": "^1.13.0",
-    "xsigners-sdk-test": "^0.0.11"
+    "xsigners-sdk-test": "^0.0.12"
   },
   "devDependencies": {
     "@storybook/addon-essentials": "^7.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11384,10 +11384,10 @@ xmlchars@^2.2.0:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
-xsigners-sdk-test@^0.0.11:
-  version "0.0.11"
-  resolved "https://registry.yarnpkg.com/xsigners-sdk-test/-/xsigners-sdk-test-0.0.11.tgz#98f91e8e4468fdc78b2603008c628defac60eef6"
-  integrity sha512-1rF10nMECoF343Ve3G8MInpDCJRTGcalKuiIgan9lKEWHScSpUThoubEJqPsPJbZ3frkyn2NQtmKwJvszB4JvA==
+xsigners-sdk-test@^0.0.12:
+  version "0.0.12"
+  resolved "https://registry.yarnpkg.com/xsigners-sdk-test/-/xsigners-sdk-test-0.0.12.tgz#d927ddf578d34e03882173beb2279c1179eb344c"
+  integrity sha512-APOwqj07DTazB2zpuuOnFQIr73dZteVmXY46kZ5LH/iJBHSH4MCG+3p5uAX0jFQI1lOY4D8nzZsK1g/1ZbUs8g==
   dependencies:
     "@727-ventures/typechain-types" "^1.1.2"
     "@polkadot/api" "^10.7.2"


### PR DESCRIPTION
- Update `xsigner-sdk-test` package to get new [MultisigFactory v3](https://github.com/protofire/xsigners-sdk/blob/main/src/constants/index.ts#L4).