### PR TITLE
Adding reload when xsigner accountCreated is issued

### DIFF
--- a/src/context/CallerXsigerAccounts.tsx
+++ b/src/context/CallerXsigerAccounts.tsx
@@ -117,7 +117,7 @@ export const CallerXsignersAccountProvider: React.FC<PropsWithChildren> = ({
       MultisigContractEvents.OwnerAdded,
       MultisigContractEvents.OwnerRemoved,
       MultisigContractEvents.ThresholdChanged,
-      XsignerAccountEvents.newAccountCreated,
+      XsignerAccountEvents.accountCreated,
     ],
     () => fetchAndUpdateMultisigs()
   );

--- a/src/domain/events/XsignerAccountEvents.ts
+++ b/src/domain/events/XsignerAccountEvents.ts
@@ -1,5 +1,5 @@
 export const enum XsignerAccountEvents {
-  newAccountCreated = "newAccountCreated",
+  accountCreated = "accountCreated",
   onChangeAccount = "onChangeAccount",
   blockchainAccountsReloaded = "blockchainAccountsReloaded",
 }

--- a/src/hooks/xsignersAccount/useNewSignersAccount.ts
+++ b/src/hooks/xsignersAccount/useNewSignersAccount.ts
@@ -65,7 +65,7 @@ export function useNewSignersAccount(onSave: UseAddSignersAccount["save"]) {
             addNotification({ message: errorFormated, type: "error" });
           } else if (_result?.isCompleted) {
             document.dispatchEvent(
-              new CustomEvent(XsignerAccountEvents.newAccountCreated)
+              new CustomEvent(XsignerAccountEvents.accountCreated)
             );
             setNewAccount(account);
           }


### PR DESCRIPTION
# Bug
When you create a new account and you back to welcome page, you can't see the new account.

## Proposal
Reload Xsigner account by caller account connected when `accountCreated` is issued